### PR TITLE
Momo 74 로그인 프로세스 	수정

### DIFF
--- a/src/api/userAuthApi.js
+++ b/src/api/userAuthApi.js
@@ -3,33 +3,65 @@ import {AUTH_API_URL, API_KEY, FIRESTORE_API_URL, PROJECT_ID} from '@env';
 
 import {storeAuthToken} from '../utils/utils';
 
-const signInAnonymously = async (callBack) => {
-  try{
-    const response = await axios.post(
-      `${AUTH_API_URL}accounts:signUp?key=${API_KEY}`,
-      {
-        returnSecureToken: true,
-      },
-    ).then(response => {
-      return response
-    }).catch( e => {
-      console.log(e);
-    });    
-    await userDocumnetSetup(response.data.idToken);
-    await storeAuthToken(response.data.idToken).then(()=>{callBack(response.data.idToken)});
-  } catch (error) {
-    console.error(error);
-  }
+export const signUpAnonymously = async (callBack) => {
+
+  const response = await axios.post(
+    `${AUTH_API_URL}accounts:signUp?key=${API_KEY}`,
+    {
+      'returnSecureToken': true,
+    },
+  ).then(response => {
+    return response.data
+  }).catch( e => {
+    console.log(e);
+  });    
+  await storeAuthToken(response.localId).then(()=>{callBack(response.localId)});
+  return response.localId;
 };
 
-const userDocumnetSetup = async (token) => {
-  try{
-    await axios.post(
-      `${FIRESTORE_API_URL}${PROJECT_ID}/databases/(default)/documents/User_Collection?documentId=${token}`
-    )
-  } catch (error) {
-    console.error(error);
-  }
-}
+// 추후 사용 예정
+export const signInWithToken = async (token) => {
+  const uuid = await axios.post(
+    `${AUTH_API_URL}accounts:signInWithCustomToken?key=${API_KEY}`,
+    {
+      'token': token,
+      'returnSecureToken': true,
+    }
+  ).then(response => {
+    console.log(response);
+    return response
+  }).catch(e => {
+    console.log(e);
+  })
+  
+  return uuid;
+} 
 
-export {signInAnonymously};
+export const userDocumnetSetup = async (uuid) => {
+  const data = {
+    fields: {
+      email: { stringValue: 'alpha@user.com' },
+      is_activated: { booleanValue: false },
+      momo_exp: { integerValue: 0 },
+      password: { stringValue: 'password' },
+      routine_complete_time: { timestampValue: '2023-03-22T12:30:00.834Z' },
+      streak: { integerValue: 0 },
+      user_name: { stringValue: 'alpha 사용자' },
+      wake_up_time: { timestampValue: '2023-03-22T12:30:00.834Z' }, 
+    }
+  };
+  
+  await axios.patch(
+    `${FIRESTORE_API_URL}${PROJECT_ID}/databases/(default)/documents/User_Collection/${uuid}`,
+      data,
+      {
+        headers: {
+          'Content-type': 'application/json',
+        },
+      }
+    ).then(response => {
+      return response
+    }).catch(e => {
+      console.log(e);
+    })
+}

--- a/src/redux/reducerSlices/userSlice.js
+++ b/src/redux/reducerSlices/userSlice.js
@@ -1,148 +1,169 @@
-import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
-import { getUserBasic, patchUser } from '../../api/userApi';
+import {createAsyncThunk, createSlice} from '@reduxjs/toolkit';
+import {getUserBasic, patchUser} from '../../api/userApi';
 
 const initialState = {
-    isLoading: true,
-    isApiLoading: false,
-    error: null,
-    signedIn: false,
-    momoActivated: false,
-    streak: 0,
-    level: 0,
-    exp: 0,
-    requiredPointToNextLevel: 0,
-    currentPoint: 0,
-    remainingPoint: 0,
-    progress: 0,
-    wakeUpTime: null,
-    completeTime: null,
-    isTutorialFinished: false,
+  UUID: '',
+  isLoading: true,
+  isApiLoading: false,
+  error: null,
+  signedIn: false,
+  momoActivated: false,
+  streak: 0,
+  level: 0,
+  exp: 0,
+  requiredPointToNextLevel: 0,
+  currentPoint: 0,
+  remainingPoint: 0,
+  progress: 0,
+  wakeUpTime: null,
+  completeTime: null,
+  isTutorialFinished: false,
 };
 
 const requiredPointDict = {
-    // this is accumulative
-    1: 20,
-    2: 62,
-    3: 128,
-    4: 220,
-    5: 340,
-    6: 490,
-    7: 690,
-    8: 955,
-    9: 1330,
-    10: 1825,
+  // this is accumulative
+  1: 20,
+  2: 62,
+  3: 128,
+  4: 220,
+  5: 340,
+  6: 490,
+  7: 690,
+  8: 955,
+  9: 1330,
+  10: 1825,
 };
 
 function updateLevel(exp) {
-    for (const level in requiredPointDict) {
-        if (requiredPointDict[level] > exp) {
-            return parseInt(level);
-        }
+  for (const level in requiredPointDict) {
+    if (requiredPointDict[level] > exp) {
+      return parseInt(level);
     }
+  }
 }
 
 function updateRequiredPointToNextLevel(level) {
-    if (level > 1) {
-        return requiredPointDict[level] - requiredPointDict[level - 1];
-    } else {
-        return requiredPointDict[level];
-    }
+  if (level > 1) {
+    return requiredPointDict[level] - requiredPointDict[level - 1];
+  } else {
+    return requiredPointDict[level];
+  }
 }
 
 function updateCurrentPoint(level, exp) {
-    if (level > 1) {
-        return exp - requiredPointDict[level - 1];
-    } else {
-        return exp;
-    }
+  if (level > 1) {
+    return exp - requiredPointDict[level - 1];
+  } else {
+    return exp;
+  }
 }
 
 export const fetchUserBasic = createAsyncThunk(
-    'userSlice/fetchUserBasic',
-    async () => {
-        const response = await getUserBasic();
-        return response.data;
-    }
+  'userSlice/fetchUserBasic',
+  async () => {
+    const response = await getUserBasic();
+    return response.data;
+  },
 );
 
 export const userSlice = createSlice({
-    name: 'user',
-    initialState,
-    reducers: {
-        setLoading: (state) => {
-            state.isLoading = false;
+  name: 'user',
+  initialState,
+  reducers: {
+    setUUID: (state, action) => {
+      state.UUID = action.payload;
+    },
+    setLoading: (state) => {
+      state.isLoading = false;
+    },
+    login: (state) => {
+      state.signedIn = true;
+    },
+    logout: (state) => {
+      state.signedIn = false;
+    },
+    activateMomo: (state) => {
+      state.momoActivated = true;
+    },
+    updateExp: (state, action) => {
+      switch (action.payload.case) {
+        case 'INCREMENT_EXP':
+          state.exp += action.payload.amount;
+          break;
+        case 'DECREMENT_EXP':
+          state.exp -= action.payload.amount;
+          if (state.exp < 0) {
+            state.exp = 0;
+          }
+          break;
+        default:
+          state;
+      }
+      state.level = updateLevel(state.exp);
+      state.requiredPointToNextLevel = updateRequiredPointToNextLevel(
+        state.level,
+      );
+      state.currentPoint = updateCurrentPoint(state.level, state.exp);
+      state.remainingPoint =
+        state.requiredPointToNextLevel - state.currentPoint;
+      state.progress = state.currentPoint / state.requiredPointToNextLevel;
+      const dataBody = {
+        fields: {
+          momo_exp: {
+            integerValue: state.exp,
+          },
         },
-        login: (state) => {
-            state.signedIn = true;
-        },
-        logout: (state) => {
-            state.signedIn = false;
-        },
-        activateMomo: (state) => {
-            state.momoActivated = true;
-        },
-        updateExp: (state, action) => {
-            switch (action.payload.case) {
-                case 'INCREMENT_EXP':
-                    state.exp += action.payload.amount;
-                    break;
-                case 'DECREMENT_EXP':
-                    state.exp -= action.payload.amount;
-                    if (state.exp < 0) {
-                        state.exp = 0;
-                    }
-                    break;
-                default:
-                    state;
-            }
-            state.level = updateLevel(state.exp);
-            state.requiredPointToNextLevel = updateRequiredPointToNextLevel(state.level);
-            state.currentPoint = updateCurrentPoint(state.level, state.exp);
-            state.remainingPoint = state.requiredPointToNextLevel - state.currentPoint;
-            state.progress = state.currentPoint / state.requiredPointToNextLevel;
-            const dataBody = {
-                fields: {
-                    momo_exp: {
-                        integerValue: state.exp,
-                    },
-                },
-            };
+      };
 
-            patchUser(dataBody, ['momo_exp']);
-        },
-        setWakeUpTime: (state, action) => {
-            state.wakeUpTime = action.payload.wakeUpTime;
-        },
-        setCompleteTime: (state, action) => {
-            state.completeTime = action.payload.completeTime;
-        },
-        setIsTutorialFinished: (state, action) => {
-            state.isTutorialFinished = action.payload.isTutorialFinished;
-        },
+      patchUser(dataBody, ['momo_exp']);
     },
-    extraReducers: (builder) => {
-        builder
-            .addCase(fetchUserBasic.pending, (state) => {
-                state.isApiLoading = true;
-            })
-            .addCase(fetchUserBasic.fulfilled, (state, action) => {
-                state.isApiLoading = false;
-                const data = action.payload.fields;
-                state.exp = parseInt(data.momo_exp.integerValue);
-                state.level = updateLevel(state.exp);
-                state.requiredPointToNextLevel = updateRequiredPointToNextLevel(state.level);
-                state.currentPoint = updateCurrentPoint(state.level, state.exp);
-                state.remainingPoint = state.requiredPointToNextLevel - state.currentPoint;
-                state.progress = state.currentPoint / state.requiredPointToNextLevel;
-                state.wakeUpTime = Date.parse(data.wake_up_time.timestampValue) / 1000;
-                state.completeTime = Date.parse(data.routine_complete_time.timestampValue) / 1000;
-            })
-            .addCase(fetchUserBasic.rejected, (state, action) => {
-                state.isApiLoading = false;
-                state.error = action.error.message;
-            });
+    setWakeUpTime: (state, action) => {
+      state.wakeUpTime = action.payload.wakeUpTime;
     },
+    setCompleteTime: (state, action) => {
+      state.completeTime = action.payload.completeTime;
+    },
+    setIsTutorialFinished: (state, action) => {
+      state.isTutorialFinished = action.payload.isTutorialFinished;
+    },
+  },
+  extraReducers: builder => {
+    builder
+      .addCase(fetchUserBasic.pending, state => {
+        state.isApiLoading = true;
+      })
+      .addCase(fetchUserBasic.fulfilled, (state, action) => {
+        state.isApiLoading = false;
+        const data = action.payload.fields;
+        state.exp = parseInt(data.momo_exp.integerValue);
+        state.level = updateLevel(state.exp);
+        state.requiredPointToNextLevel = updateRequiredPointToNextLevel(
+          state.level,
+        );
+        state.currentPoint = updateCurrentPoint(state.level, state.exp);
+        state.remainingPoint =
+          state.requiredPointToNextLevel - state.currentPoint;
+        state.progress = state.currentPoint / state.requiredPointToNextLevel;
+        state.wakeUpTime = Date.parse(data.wake_up_time.timestampValue) / 1000;
+        state.completeTime =
+          Date.parse(data.routine_complete_time.timestampValue) / 1000;
+      })
+      .addCase(fetchUserBasic.rejected, (state, action) => {
+        state.isApiLoading = false;
+        state.error = action.error.message;
+      });
+  },
 });
 
-export const { setLoading, login, logout, activateMomo, updateExp, setWakeUpTime, setCompleteTime, setIsTutorialFinished } = userSlice.actions;
+export const {
+  setUUID,
+  setLoading,
+  login,
+  logout,
+  activateMomo,
+  updateExp,
+  setWakeUpTime,
+  setCompleteTime,
+  setIsTutorialFinished,
+} = userSlice.actions;
 export default userSlice.reducer;

--- a/src/screens/LoadingScreen.js
+++ b/src/screens/LoadingScreen.js
@@ -3,7 +3,7 @@ import React, { useEffect } from 'react';
 import {useDispatch,useSelector} from 'react-redux';
 
 import LoadingImage from '../assets/images/Intro_animation.gif';
-import {login,logout} from '../redux/reducerSlices/userSlice';
+import {login,logout,setUUID} from '../redux/reducerSlices/userSlice';
 import {getAuthToken} from '../utils/utils';
 
 
@@ -13,6 +13,7 @@ const LoadingScreen = () => {
   const checkAuthUser = async () => {
     getAuthToken((token) => {
       if(token) {
+        dispatch(setUUID(token));
         dispatch(login());
       } else {
         dispatch(logout());

--- a/src/screens/LoginScreenAlpha.js
+++ b/src/screens/LoginScreenAlpha.js
@@ -2,19 +2,20 @@ import React from 'react';
 import {StyleSheet,Text,View,Image,SafeAreaView,TouchableOpacity,} from 'react-native';
 import {useDispatch} from 'react-redux';
 
-import {login} from '../redux/reducerSlices/userSlice';
+import {login,setUUID} from '../redux/reducerSlices/userSlice';
 import LogoImage from '../assets/images/Logo.png';
-import {signInAnonymously} from '../api/userAuthApi';
+import {signUpAnonymously, userDocumnetSetup} from '../api/userAuthApi';
 
-import axios from 'axios';
 
 const LoginScreen = () => {
   const dispatch = useDispatch();
 
   const handleAnonymousLoginPress = async () => {
-    await signInAnonymously(async() => {
+    const uuid = await signUpAnonymously(async() => {
       dispatch(login());
     });
+    dispatch(setUUID(uuid));
+    userDocumnetSetup(uuid)
   };
 
 


### PR DESCRIPTION
# Changes
- 기존 token을 device에 저장하던 로직을 버리고, uuid를 저장하는 방식을 채택
- uuid를 asyncStorage에 저장하고 앱 실행 or 회원가입과 동시에 state에 uuid를 저장
- 사용자 정보를 가져올 때 state의 uuid를 활용해 api호출

